### PR TITLE
Finalize minicontratos basic setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
-SUPABASE_URL=https://xxxx.supabase.co
-SUPABASE_KEY=eyJ...
+SUPABASE_URL=https://zcsbfkatxfwafastugfq.supabase.co
+SUPABASE_KEY=eyJhbGciOiJIUzI1NiIsInR5...
+DATABASE_URL=postgresql://postgres.zcsbfkatxfwafastugfq:vehteb-qirzyr-reMpe9@aws-0-eu-west-2.pooler.supabase.com:6543/postgres
 LOG_FALLBACK_PATH=logline.voulezvous.jsonl

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 install:
 	bash install.sh
 
-test:
-	python -m pytest -q
+run:
+	flask --app backend.app run
 
 sync:
 	python backend/sync_fallback.py
+
+test:
+	python -m unittest discover tests
+
+clean:
+	rm -f logline.voulezvous.jsonl

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,0 +1,14 @@
+<script>
+</script>
+
+<nav>
+  <a href="/logline">LogLine</a>
+  <a href="/communicator">Communicator</a>
+  <a href="/new">New</a>
+</nav>
+<slot />
+
+<style>
+  nav { display: flex; gap: 1rem; justify-content: center; padding: 1rem; }
+  a { text-decoration: none; font-size: 1.2rem; }
+</style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,41 +1,7 @@
-<script>
-  import { onMount } from 'svelte';
-  let text = '';
-  let feedback = '';
-  let suggestions = [];
-
-  onMount(async () => {
-    const res = await fetch('/prompts.extended 2.json');
-    suggestions = await res.json();
-  });
-
-  async function register() {
-    feedback = 'Enviando...';
-    const res = await fetch('/register', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ this: text, who: 'user', did: 'report', when: new Date().toISOString(), confirmed_by: '', if_ok: '', if_doubt: '', if_not: '', status: 'pending' })
-    });
-    const data = await res.json();
-    feedback = data.status;
-    text = '';
-  }
-</script>
-
+<script></script>
 <main>
-  <input list="sug" bind:value={text} placeholder="o que aconteceu?" />
-  <datalist id="sug">
-    {#each suggestions as sug}
-      <option value={sug} />
-    {/each}
-  </datalist>
-  <button on:click={register}>Registrar</button>
-  {#if feedback}
-    <p>{feedback}</p>
-  {/if}
+  <h1>Escolha um modo</h1>
 </main>
-
 <style>
-  main { display: flex; flex-direction: column; gap: 0.5rem; max-width: 400px; margin: auto; }
-  input, button { font-size: 1.2rem; }
+  main { text-align: center; margin-top: 2rem; }
 </style>

--- a/frontend/src/routes/communicator/+page.svelte
+++ b/frontend/src/routes/communicator/+page.svelte
@@ -1,0 +1,33 @@
+<script>
+  let messages = [];
+  let text = '';
+  async function send() {
+    if (!text) return;
+    messages = [...messages, { from: 'me', text }];
+    const res = await fetch('/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ this: text, who: 'user', did: 'said', when: new Date().toISOString(), confirmed_by: '', if_ok: '', if_doubt: '', if_not: '', status: 'pending' })
+    });
+    const data = await res.json();
+    messages = [...messages, { from: 'server', text: data.status }];
+    text = '';
+  }
+</script>
+
+<main>
+  <div class="history">
+    {#each messages as msg}
+      <div class={msg.from}>{msg.text}</div>
+    {/each}
+  </div>
+  <input bind:value={text} placeholder="mensagem" on:keydown={(e)=>e.key==='Enter' && send()} />
+  <button on:click={send}>Enviar</button>
+</main>
+
+<style>
+  main { display: flex; flex-direction: column; gap: 0.5rem; max-width: 400px; margin: auto; }
+  .history { min-height: 200px; border: 1px solid #ccc; padding: 0.5rem; overflow-y: auto; }
+  .me { text-align: right; }
+  input, button { font-size: 1rem; }
+</style>

--- a/frontend/src/routes/logline/+page.svelte
+++ b/frontend/src/routes/logline/+page.svelte
@@ -1,0 +1,41 @@
+<script>
+  import { onMount } from 'svelte';
+  let text = '';
+  let feedback = '';
+  let suggestions = [];
+
+  onMount(async () => {
+    const res = await fetch('/prompts');
+    suggestions = await res.json();
+  });
+
+  async function register() {
+    feedback = 'Enviando...';
+    const res = await fetch('/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ this: text, who: 'user', did: 'report', when: new Date().toISOString(), confirmed_by: '', if_ok: '', if_doubt: '', if_not: '', status: 'pending' })
+    });
+    const data = await res.json();
+    feedback = data.status;
+    text = '';
+  }
+</script>
+
+<main>
+  <input list="sug" bind:value={text} placeholder="o que aconteceu?" />
+  <datalist id="sug">
+    {#each suggestions as sug}
+      <option value={sug} />
+    {/each}
+  </datalist>
+  <button on:click={register}>Registrar</button>
+  {#if feedback}
+    <p>{feedback}</p>
+  {/if}
+</main>
+
+<style>
+  main { display: flex; flex-direction: column; gap: 0.5rem; max-width: 400px; margin: auto; }
+  input, button { font-size: 1.2rem; }
+</style>

--- a/frontend/src/routes/new/+page.svelte
+++ b/frontend/src/routes/new/+page.svelte
@@ -1,0 +1,31 @@
+<script>
+  let form = { who: '', did: '', this: '', when: '', confirmed_by: '', if_ok: '', if_doubt: '', if_not: '', status: 'pending' };
+  async function register() {
+    const res = await fetch('/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    });
+    const data = await res.json();
+    alert(data.status);
+  }
+</script>
+
+<main>
+  <label>Quem<input bind:value={form.who} /></label>
+  <label>Fez<input bind:value={form.did} /></label>
+  <label>O quê<input bind:value={form.this} /></label>
+  <label>Quando<input bind:value={form.when} type="datetime-local" /></label>
+  <label>Confirmado por<input bind:value={form.confirmed_by} /></label>
+  <label>Se ok<input bind:value={form.if_ok} /></label>
+  <label>Se dúvida<input bind:value={form.if_doubt} /></label>
+  <label>Se não<input bind:value={form.if_not} /></label>
+  <label>Status<input bind:value={form.status} /></label>
+  <button on:click={register}>Registrar</button>
+</main>
+
+<style>
+  main { display: flex; flex-direction: column; gap: 0.5rem; max-width: 400px; margin: auto; }
+  label { display: flex; flex-direction: column; font-size: 0.9rem; }
+  input, button { font-size: 1rem; }
+</style>

--- a/install.sh
+++ b/install.sh
@@ -5,4 +5,6 @@ source venv/bin/activate
 pip install -r requirements.txt
 if [ -d frontend ]; then
   cd frontend && npm install || true
+  cd ..
 fi
+mkdir -p logs data


### PR DESCRIPTION
## Summary
- load env vars with `dotenv`
- provide `/prompts` and `/timeline` routes
- fetch prompts from the frontend
- create install script folders
- add Makefile targets
- update env example
- add multi-mode frontend pages for logline, communicator and new forms

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'flask')*
