### PR TITLE
Fix Flask fallback for testing

### DIFF
--- a/backend/flask_stub.py
+++ b/backend/flask_stub.py
@@ -1,0 +1,48 @@
+import json
+
+class _Request:
+    def __init__(self):
+        self._json = None
+        self.data = b''
+
+    def get_json(self):
+        return self._json
+
+request = _Request()
+
+class Response:
+    def __init__(self, data, status=200):
+        self.data = data.encode() if isinstance(data, str) else data
+        self.status_code = status
+
+
+def jsonify(obj):
+    return Response(json.dumps(obj), 200)
+
+class Flask:
+    def __init__(self, name):
+        self.name = name
+        self._routes = {}
+
+    def route(self, path, methods=None):
+        methods = tuple((methods or ['GET']))
+        def decorator(func):
+            self._routes[(path, methods)] = func
+            return func
+        return decorator
+
+    def test_client(self):
+        app = self
+        class Client:
+            def post(self, path, json=None, data=None):
+                request._json = json
+                request.data = data.encode() if isinstance(data, str) else (data or b'')
+                func = app._routes.get((path, ('POST',)))
+                rv = func()
+                if isinstance(rv, Response):
+                    return rv
+                if isinstance(rv, tuple):
+                    body, status = rv
+                    return Response(json.dumps(body), status)
+                return Response(str(rv))
+        return Client()

--- a/backend/llm_service.py
+++ b/backend/llm_service.py
@@ -12,3 +12,13 @@ def parse_text_to_logline(text: str) -> dict:
         'status': parts[8].strip() if len(parts) > 8 else 'pending'
     }
     return logline
+
+
+def interpretar_frase(frase: str) -> dict:
+    """Alias semântico para `parse_text_to_logline`.
+
+    A função original continua existindo para compatibilidade
+    com os testes, mas o sistema pode invocar este nome mais
+    descritivo conforme definido nos prompts institucionais.
+    """
+    return parse_text_to_logline(frase)

--- a/logline.example.jsonl
+++ b/logline.example.jsonl
@@ -1,0 +1,2 @@
+{"who":"alice","did":"report","this":"teste","when":"2023-01-01","confirmed_by":"bob","if_ok":"ok","if_doubt":"doubt","if_not":"fail","status":"pending","valid":true}
+{"who":"carol","did":"fail","this":"error","when":"2023-01-02","confirmed_by":"","if_ok":"","if_doubt":"","if_not":"notify","status":"pending","valid":false}


### PR DESCRIPTION
## Summary
- restore lightweight Flask fallback so `backend.app` works without dependencies
- re-enable fallback imports for Supabase and dotenv

## Testing
- `make test`